### PR TITLE
Mark image as not dirty when processed

### DIFF
--- a/src/win32/main.cpp
+++ b/src/win32/main.cpp
@@ -1304,6 +1304,8 @@ static void render()
             }
             tex->Release();
         }
+
+        V->imageDirty_ = 0;
     }
 
     context_->OMSetRenderTargets(1, &renderTarget_, nullptr);


### PR DESCRIPTION
This seems to be a bug that was causing the D3D textures to be recreated every render frame.