### PR TITLE
Fix crash when d3d texture creation fails

### DIFF
--- a/src/win32/main.cpp
+++ b/src/win32/main.cpp
@@ -1257,7 +1257,9 @@ static void render()
                     return;
                 }
             }
-            tex->Release();
+            if (tex) {
+                tex->Release();
+            }
         }
 
         if (cieBackground_) {
@@ -1302,7 +1304,9 @@ static void render()
                     return;
                 }
             }
-            tex->Release();
+            if (tex) {
+                tex->Release();
+            }
         }
     }
 


### PR DESCRIPTION
Guard against crashing when D3D texture creation fails, for example with image sizes greater than the D3D texture limits.